### PR TITLE
fix: 解决使用sentry时日志异常未能按照预期聚合的问题

### DIFF
--- a/docs/CHANGELOG-1.x.md
+++ b/docs/CHANGELOG-1.x.md
@@ -5,8 +5,9 @@
     - 调整logger输出日志使用“模板”
     - 修复：try finally中使用日志输出异常无法正常获取异常堆栈
     - 装饰器中日志输出日志模板增加了location信息作为聚合因子
-- fix: `handle_exception` 增加参数`logger_pre_level`
-    - 避免重试引起多次sentry错误上报
+- fix: 调整 `handle_exception`
+    - 增加参数`logger_pre_level`，避免重试引起多次sentry错误上报
+    - 优化调整`raise error`逻辑放在了except语句块中，直接raise
 
 ## 1.2.4
 - fix: 调整 `exec_command` 使用原生的 `subprocess.run` 超时参数设置

--- a/docs/CHANGELOG-1.x.md
+++ b/docs/CHANGELOG-1.x.md
@@ -1,5 +1,12 @@
 # Release Notes
 
+## 1.2.5
+- fix: 解决使用sentry时日志异常未能按照预期聚合的问题
+    - 调整logger输出日志使用“模板”
+    - 修复：try finally中使用日志输出异常无法正常获取异常堆栈
+- fix: `handle_exception` 增加参数`logger_pre_level`
+    - 避免重试引起多次sentry错误上报
+
 ## 1.2.4
 - fix: 调整 `exec_command` 使用原生的 `subprocess.run` 超时参数设置
     - 解决 threading.Timer 超时带来的僵尸进程问题

--- a/docs/CHANGELOG-1.x.md
+++ b/docs/CHANGELOG-1.x.md
@@ -4,6 +4,7 @@
 - fix: 解决使用sentry时日志异常未能按照预期聚合的问题
     - 调整logger输出日志使用“模板”
     - 修复：try finally中使用日志输出异常无法正常获取异常堆栈
+    - 装饰器中日志输出日志模板增加了location信息作为聚合因子
 - fix: `handle_exception` 增加参数`logger_pre_level`
     - 避免重试引起多次sentry错误上报
 

--- a/pykit_tools/__init__.py
+++ b/pykit_tools/__init__.py
@@ -7,7 +7,7 @@ import importlib
 
 
 __all__ = ["settings", "VERSION"]
-__version__ = "1.2.4"
+__version__ = "1.2.5"
 
 
 VERSION = __version__

--- a/pykit_tools/cmd.py
+++ b/pykit_tools/cmd.py
@@ -41,6 +41,7 @@ def exec_command(
     if popen_kwargs:
         kwargs.update(popen_kwargs)
 
+    _name = command.split()[0]  # 命令名称
     stdout, stderr = "", ""
     try:
         result: subprocess.CompletedProcess = subprocess.run(command, capture_output=True, timeout=timeout, **kwargs)
@@ -49,7 +50,7 @@ def exec_command(
         stderr = result.stderr
     except subprocess.TimeoutExpired:
         code = -9
-        logging.getLogger(logger_name).log(logger_level, "[timeout %s %s] code=%s", timeout, command, code)
+        logging.getLogger(logger_name).log(logger_level, f"{_name} [timeout %s %s] code=%s", timeout, command, code)
     else:
         if code != 0 and err_max_length > 0:
             log_err = stderr or ""
@@ -58,9 +59,9 @@ def exec_command(
                 pre_idx = err_max_length // 2
                 log_err = log_err[:pre_idx] + "\n\t...\n" + log_err[:-pre_idx]
             logging.getLogger(logger_name).log(
-                logger_level, "[timeout %s %s] code=%s\n\tstderr: %s", timeout, command, code, log_err
+                logger_level, f"[{_name}] [timeout %s %s] code=%s\n\tstderr: %s", timeout, command, code, log_err
             )
         elif log_cmd:
-            logging.getLogger(logger_name).info("[timeout %s %s] code=%s", timeout, command, code)
+            logging.getLogger(logger_name).info(f"{_name} [timeout %s %s] code=%s", timeout, command, code)
 
     return code, stdout, stderr

--- a/pykit_tools/cmd.py
+++ b/pykit_tools/cmd.py
@@ -32,8 +32,6 @@ def exec_command(
         stderr 执行错误输出
 
     """
-    _log_cmd = f"[timeout {timeout} {command}]"
-
     kwargs: typing.Dict = {
         "text": True,
         "shell": True,
@@ -51,18 +49,18 @@ def exec_command(
         stderr = result.stderr
     except subprocess.TimeoutExpired:
         code = -9
-
-    # 记录日志
-    _msg = f"{_log_cmd} code={code}"
-    if code != 0 and err_max_length > 0:
-        log_err = stderr or ""
-        if len(stderr) > err_max_length:
-            # 截取前后一半，中间用...代替
-            pre_idx = err_max_length // 2
-            log_err = stderr[:pre_idx] + "\n\t...\n" + stderr[:-pre_idx]
-        _msg = f"{_msg}\n\tstderr: {log_err}"
-        logging.getLogger(logger_name).log(logger_level, _msg)
-    elif log_cmd:
-        logging.getLogger(logger_name).info(_msg)
+        logging.getLogger(logger_name).log(logger_level, "[timeout %s %s] code=%s", timeout, command, code)
+    else:
+        if code != 0 and err_max_length > 0:
+            log_err = stderr or ""
+            if len(log_err) > err_max_length:
+                # 截取前后一半，中间用...代替
+                pre_idx = err_max_length // 2
+                log_err = log_err[:pre_idx] + "\n\t...\n" + log_err[:-pre_idx]
+            logging.getLogger(logger_name).log(
+                logger_level, "[timeout %s %s] code=%s\n\tstderr: %s", timeout, command, code, log_err
+            )
+        elif log_cmd:
+            logging.getLogger(logger_name).info("[timeout %s %s] code=%s", timeout, command, code)
 
     return code, stdout, stderr

--- a/pykit_tools/cmd.py
+++ b/pykit_tools/cmd.py
@@ -50,7 +50,7 @@ def exec_command(
         stderr = result.stderr
     except subprocess.TimeoutExpired:
         code = -9
-        logging.getLogger(logger_name).log(logger_level, f"{_name} [timeout %s %s] code=%s", timeout, command, code)
+        logging.getLogger(logger_name).log(logger_level, f"{_name} code %s timeout %s %s", code, timeout, command)
     else:
         if code != 0 and err_max_length > 0:
             log_err = stderr or ""
@@ -59,9 +59,9 @@ def exec_command(
                 pre_idx = err_max_length // 2
                 log_err = log_err[:pre_idx] + "\n\t...\n" + log_err[:-pre_idx]
             logging.getLogger(logger_name).log(
-                logger_level, f"[{_name}] [timeout %s %s] code=%s\n\tstderr: %s", timeout, command, code, log_err
+                logger_level, f"{_name} code %s timeout %s %s\n\tstderr: %s", code, timeout, command, log_err
             )
         elif log_cmd:
-            logging.getLogger(logger_name).info(f"{_name} [timeout %s %s] code=%s", timeout, command, code)
+            logging.getLogger(logger_name).info(f"{_name} code %s timeout %s %s", code, timeout, command)
 
     return code, stdout, stderr

--- a/pykit_tools/decorators/cache.py
+++ b/pykit_tools/decorators/cache.py
@@ -102,6 +102,7 @@ def method_deco_cache(
         )
 
     fn = typing.cast(typing.Callable, func)
+    _location = utils.get_caller_location(fn)
 
     _redis_conf = pykit_tools.settings.APP_CACHE_REDIS
     if _redis_conf:
@@ -129,7 +130,9 @@ def method_deco_cache(
                 data = json.loads(value)
                 has_cache = True
         except Exception:
-            logging.getLogger(logger_name).log(logger_level, "load cache_data error key=%s", _key, exc_info=True)
+            logging.getLogger(logger_name).log(
+                logger_level, f"{_location} load cache_data error key=%s", _key, exc_info=True
+            )
         return has_cache, data
 
     def __allow_value_cache(value: typing.Any) -> bool:
@@ -156,8 +159,7 @@ def method_deco_cache(
         if key:
             _key = key(*args, **kwargs) if callable(key) else key
         else:
-            location = utils.get_caller_location(fn)
-            _key = f"method:{fn.__name__}:{str_tool.compute_md5(location, *args, **kwargs)}"
+            _key = f"method:{fn.__name__}:{str_tool.compute_md5(_location, *args, **kwargs)}"
 
         # 可传递 skip 不读取缓存
         if _scene in (CacheScene.DEFAULT.value,):
@@ -186,13 +188,13 @@ def method_deco_cache(
             _cache_str = json.dumps(ret, separators=(",", ":"))
             if len(_cache_str) > cache_max_length:
                 logging.getLogger(logger_name).log(
-                    logger_level, "Cache too long, key=%s limit is %s", _key, cache_max_length
+                    logger_level, f"{_location} Cache too long, key=%s limit is %s", _key, cache_max_length
                 )
             else:
                 _client.set(_key, _cache_str, timeout)
         except Exception:
             logging.getLogger(logger_name).log(
-                logger_level, "set cache_data error key=%s ret=%s", _key, ret, exc_info=True
+                logger_level, f"{_location} set cache_data error key=%s ret=%s", _key, ret, exc_info=True
             )
 
         return ret

--- a/pykit_tools/decorators/cache.py
+++ b/pykit_tools/decorators/cache.py
@@ -129,7 +129,7 @@ def method_deco_cache(
                 data = json.loads(value)
                 has_cache = True
         except Exception:
-            logging.getLogger(logger_name).log(logger_level, f"load cache_data error key={_key}", exc_info=True)
+            logging.getLogger(logger_name).log(logger_level, "load cache_data error key=%s", _key, exc_info=True)
         return has_cache, data
 
     def __allow_value_cache(value: typing.Any) -> bool:
@@ -186,13 +186,13 @@ def method_deco_cache(
             _cache_str = json.dumps(ret, separators=(",", ":"))
             if len(_cache_str) > cache_max_length:
                 logging.getLogger(logger_name).log(
-                    logger_level, f"Cache too long, key={_key} limit is {cache_max_length}"
+                    logger_level, "Cache too long, key=%s limit is %s", _key, cache_max_length
                 )
             else:
                 _client.set(_key, _cache_str, timeout)
         except Exception:
             logging.getLogger(logger_name).log(
-                logger_level, f"set cache_data error key={_key} ret={ret}", exc_info=True
+                logger_level, "set cache_data error key=%s ret=%s", _key, ret, exc_info=True
             )
 
         return ret

--- a/pykit_tools/decorators/common.py
+++ b/pykit_tools/decorators/common.py
@@ -7,7 +7,6 @@ import typing
 from functools import wraps, partial
 
 from pykit_tools.utils import get_caller_location
-from pykit_tools.log.adapter import get_format_logger
 
 
 def handle_exception(
@@ -21,6 +20,7 @@ def handle_exception(
     log_args: bool = True,
     logger_name: str = "pykit_tools.error",
     logger_level: int = logging.ERROR,
+    logger_pre_level: int = logging.WARNING,
 ) -> typing.Callable:
     """
     `装饰器` 用于捕获函数异常，并在出现异常的时候返回默认值
@@ -37,6 +37,7 @@ def handle_exception(
         log_args: 异常时将参数输出到日志
         logger_name: 日志名称，仅记录异常时使用
         logger_level: 异常时设置日志的级别
+        logger_pre_level: 重试最后一次之前的日志级别，避免多次重试会有多次错误输出
 
     Returns:
         function
@@ -54,6 +55,7 @@ def handle_exception(
             log_args=log_args,
             logger_name=logger_name,
             logger_level=logger_level,
+            logger_pre_level=logger_pre_level,
         )
 
     fn = typing.cast(typing.Callable, func)
@@ -72,10 +74,27 @@ def handle_exception(
                 error = None
             except Exception as e:
                 error = e
-                _msg = "%s retry=%d %s" % (location, count, str(e))
+                _level = logger_level if count >= max_retries else logger_pre_level
                 if log_args:
-                    _msg = "%s\nargs: %s\nkwargs: %s" % (_msg, args, kwargs)
-                logging.getLogger(logger_name).log(logger_level, _msg, exc_info=True)
+                    logging.getLogger(logger_name).log(
+                        _level,
+                        "%s retry=%d %s\n\targs: %s\n\tkwargs: %s",
+                        location,
+                        count,
+                        str(e),
+                        args,
+                        kwargs,
+                        exc_info=True,
+                    )
+                else:
+                    logging.getLogger(logger_name).log(
+                        _level,
+                        "%s retry=%d %s",
+                        location,
+                        count,
+                        str(e),
+                        exc_info=True,
+                    )
                 if isinstance(e, retry_for):
                     # 可以记录重试
                     if retry_delay > 0:
@@ -131,38 +150,39 @@ def time_record(
 
     fn = typing.cast(typing.Callable, func)
 
-    logger = get_format_logger(logger_name, ["location", "key", "cost", "ret"])
+    logger = logging.getLogger(logger_name)
 
     @wraps(fn)
     def _wrapper(*args: typing.Any, **kwargs: typing.Any) -> typing.Any:
         _start = time.monotonic()
         location = fn.__name__
+        key = "-"
+        try:
+            if args:
+                key = str(args[0])
+            location = get_caller_location(fn)
+            if callable(format_key):
+                key = format_key(*args, **kwargs)
+        except Exception:
+            pass
 
         ret = None
         try:
             ret = fn(*args, **kwargs)
-        finally:
-            # 耗时
-            _end = time.monotonic()
-            cost = "%.3f" % ((_end - _start) * 1000)
-            # 日志记录结果
+        except Exception as exc:
+            cost = "%.3f" % ((time.monotonic() - _start) * 1000)
+            logger.log(logger_level, "%s %s %s %s", location, key, cost, exc, exc_info=True)
+            raise
+        else:
+            cost = "%.3f" % ((time.monotonic() - _start) * 1000)
             _ret = ret
-            # 日志记录的唯一标识
-            key = "-"
             try:
-                if args and len(args) > 0:
-                    key = str(args[0])
-                location = get_caller_location(fn)
-                if callable(format_key):
-                    key = format_key(*args, **kwargs)
-
                 if callable(format_ret):
                     _ret = format_ret(ret)
-                logger.info(dict(location=location, key=key, cost=cost, ret=_ret))
+                logger.info("%s %s %s %s", location, key, cost, _ret)
             except Exception as e:
-                logger.log(logger_level, dict(location=location, key=key, cost=cost, ret=str(e)), exc_info=True)
+                logger.log(logger_level, "%s %s %s %s", location, key, cost, e, exc_info=True)
 
-        # 返回正确结果
         return ret
 
     return _wrapper

--- a/pykit_tools/decorators/common.py
+++ b/pykit_tools/decorators/common.py
@@ -64,16 +64,16 @@ def handle_exception(
     def _wrapper(*args: typing.Any, **kwargs: typing.Any) -> typing.Any:
         result = None
         location = get_caller_location(fn)
-        error: typing.Optional[Exception] = Exception(f'Function "{location}" not executed')
+        has_err: bool = True
 
         count = 0
-        while error is not None and count < max_retries:
+        while has_err and count < max_retries:
             count += 1
             try:
                 result = fn(*args, **kwargs)
-                error = None
+                has_err = False
             except Exception as e:
-                error = e
+                has_err = True
                 _level = logger_pre_level if count < max_retries else logger_level
                 if log_args:
                     logging.getLogger(logger_name).log(
@@ -113,7 +113,7 @@ def handle_exception(
                         raise
                     break
 
-        if error is not None:
+        if has_err:
             result = default() if callable(default) else default
 
         return result

--- a/pykit_tools/decorators/common.py
+++ b/pykit_tools/decorators/common.py
@@ -78,8 +78,7 @@ def handle_exception(
                 if log_args:
                     logging.getLogger(logger_name).log(
                         _level,
-                        "%s retry=%d %s\n\targs: %s\n\tkwargs: %s",
-                        location,
+                        f"{location} retry=%d %s\n\targs: %s\n\tkwargs: %s",
                         count,
                         str(e),
                         args,
@@ -89,8 +88,7 @@ def handle_exception(
                 else:
                     logging.getLogger(logger_name).log(
                         _level,
-                        "%s retry=%d %s",
-                        location,
+                        f"{location} retry=%d %s",
                         count,
                         str(e),
                         exc_info=True,
@@ -171,7 +169,7 @@ def time_record(
             ret = fn(*args, **kwargs)
         except Exception as exc:
             cost = "%.3f" % ((time.monotonic() - _start) * 1000)
-            logger.log(logger_level, "%s %s %s %s", location, key, cost, exc, exc_info=True)
+            logger.log(logger_level, f"{location} %s %s %s", key, cost, exc, exc_info=True)
             raise
         else:
             cost = "%.3f" % ((time.monotonic() - _start) * 1000)
@@ -179,9 +177,9 @@ def time_record(
             try:
                 if callable(format_ret):
                     _ret = format_ret(ret)
-                logger.info("%s %s %s %s", location, key, cost, _ret)
+                logger.info(f"{location} %s %s %s", key, cost, _ret)
             except Exception as e:
-                logger.log(logger_level, "%s %s %s %s", location, key, cost, e, exc_info=True)
+                logger.log(logger_level, f"{location} %s %s %s", key, cost, e, exc_info=True)
 
         return ret
 

--- a/pykit_tools/decorators/common.py
+++ b/pykit_tools/decorators/common.py
@@ -74,7 +74,7 @@ def handle_exception(
                 error = None
             except Exception as e:
                 error = e
-                _level = logger_level if count >= max_retries else logger_pre_level
+                _level = logger_pre_level if count < max_retries else logger_level
                 if log_args:
                     logging.getLogger(logger_name).log(
                         _level,
@@ -94,21 +94,26 @@ def handle_exception(
                         exc_info=True,
                     )
                 if isinstance(e, retry_for):
-                    # 可以记录重试
-                    if retry_delay > 0:
-                        # 延迟重试
-                        delay = retry_delay
-                        if retry_jitter:
-                            delay = int(random.randint(0, 100) * delay / 100.0)
-                        if delay > 0:
-                            time.sleep(delay)
+                    # 重试场景
+                    if count < max_retries:
+                        # 延迟重试，最后一次异常时不用延迟
+                        if retry_delay > 0:
+                            delay = retry_delay
+                            if retry_jitter:
+                                delay = int(random.randint(0, 100) * delay / 100.0)
+                            if delay > 0:
+                                time.sleep(delay)
+                    else:
+                        # 最后一次异常时抛出异常
+                        if is_raise:
+                            raise
                 else:
                     # 其他异常不重试
+                    if is_raise:
+                        raise
                     break
 
         if error is not None:
-            if is_raise:
-                raise error
             result = default() if callable(default) else default
 
         return result

--- a/pykit_tools/decorators/common.py
+++ b/pykit_tools/decorators/common.py
@@ -158,9 +158,9 @@ def time_record(
         location = fn.__name__
         key = "-"
         try:
+            location = get_caller_location(fn)
             if args:
                 key = str(args[0])
-            location = get_caller_location(fn)
             if callable(format_key):
                 key = format_key(*args, **kwargs)
         except Exception:
@@ -175,7 +175,7 @@ def time_record(
             raise
         else:
             cost = "%.3f" % ((time.monotonic() - _start) * 1000)
-            _ret = ret
+            _ret = "-" if ret is None else ret
             try:
                 if callable(format_ret):
                     _ret = format_ret(ret)

--- a/pykit_tools/decorators/req_utils.py
+++ b/pykit_tools/decorators/req_utils.py
@@ -113,8 +113,10 @@ def requests_logger(
             if kwargs:
                 req_msg = f"{req_msg}\n\tkwargs: {kwargs}"
 
+        def _build_extra(*parts: str) -> str:
+            return "".join(f"\n\t{p}" for p in parts if p)
+
         response = None
-        err = ""
         code = 0
         length = 0
         resp_msg = ""
@@ -128,26 +130,37 @@ def requests_logger(
                 try:
                     resp_msg = format_resp(response) if callable(format_resp) else response.text
                 except Exception as _e:
-                    resp_msg = f"parse response.text error]: {_e}"
+                    resp_msg = "parse response.text error]: %s" % _e
         except Exception as e:
-            err = str(e)
+            cost = (time.monotonic() - _start) * 1000
+            logger.log(
+                logger_level,
+                "%s %s %s %s %.3f %s%s",
+                method.upper(),
+                url,
+                code,
+                length,
+                cost,
+                e,
+                _build_extra("request: %s" % req_msg if req_msg else ""),
+                exc_info=True,
+            )
             if raise_for and isinstance(e, raise_for):
                 raise
-        finally:
-            # 耗时
-            _end = time.monotonic()
-            cost = (_end - _start) * 1000
-            # 日志内容
-            msg = f"{method.upper()} {url} {code} {length} {cost:.3f} {err or '-'}"
-            if req_msg:
-                msg = f"{msg}\n\trequest: {req_msg}"
-            if resp_msg:
-                msg = f"{msg}\n\tresponse: {resp_msg}"
-
-            if err:
-                logger.log(logger_level, msg, exc_info=True)
-            else:
-                logger.info(msg)
+        else:
+            cost = (time.monotonic() - _start) * 1000
+            logger.info(
+                "%s %s %s %s %.3f -%s",
+                method.upper(),
+                url,
+                code,
+                length,
+                cost,
+                _build_extra(
+                    "request: %s" % req_msg if req_msg else "",
+                    "response: %s" % resp_msg if resp_msg else "",
+                ),
+            )
 
         # 返回结果
         return response

--- a/pykit_tools/decorators/req_utils.py
+++ b/pykit_tools/decorators/req_utils.py
@@ -3,6 +3,7 @@
 import typing
 import time
 import logging
+import urllib.parse
 import json as json_tool
 
 from functools import wraps, partial
@@ -112,14 +113,11 @@ def requests_logger(
                 req_msg = f"{req_msg}\n\tjson: {json_str}"
             if kwargs:
                 req_msg = f"{req_msg}\n\tkwargs: {kwargs}"
-
-        def _build_extra(*parts: str) -> str:
-            return "".join(f"\n\t{p}" for p in parts if p)
+        host = urllib.parse.urlparse(url).netloc
 
         response = None
         code = 0
         length = 0
-        resp_msg = ""
         _start = time.monotonic()
         try:
             response = fn(method, url, headers=headers, timeout=timeout, **kwargs)
@@ -131,18 +129,18 @@ def requests_logger(
                     resp_msg = format_resp(response) if callable(format_resp) else response.text
                 except Exception as _e:
                     resp_msg = "parse response.text error]: %s" % _e
+                req_msg = f"{req_msg}\n\tresponse: {resp_msg}"
         except Exception as e:
             cost = (time.monotonic() - _start) * 1000
             logger.log(
                 logger_level,
-                "%s %s %s %s %.3f %s%s",
-                method.upper(),
+                f"{host} {method.upper()} %s %s %s %.3f %s %s",
                 url,
                 code,
                 length,
                 cost,
                 e,
-                _build_extra("request: %s" % req_msg if req_msg else ""),
+                req_msg,
                 exc_info=True,
             )
             if raise_for and isinstance(e, raise_for):
@@ -150,16 +148,12 @@ def requests_logger(
         else:
             cost = (time.monotonic() - _start) * 1000
             logger.info(
-                "%s %s %s %s %.3f -%s",
-                method.upper(),
+                f"{host} {method.upper()} %s %s %s %.3f - %s",
                 url,
                 code,
                 length,
                 cost,
-                _build_extra(
-                    "request: %s" % req_msg if req_msg else "",
-                    "response: %s" % resp_msg if resp_msg else "",
-                ),
+                req_msg,
             )
 
         # 返回结果

--- a/pykit_tools/decorators/req_utils.py
+++ b/pykit_tools/decorators/req_utils.py
@@ -113,7 +113,7 @@ def requests_logger(
                 req_msg = f"{req_msg}\n\tjson: {json_str}"
             if kwargs:
                 req_msg = f"{req_msg}\n\tkwargs: {kwargs}"
-        host = urllib.parse.urlparse(url).netloc
+        host = urllib.parse.urlparse(url).netloc or "-"
 
         response = None
         code = 0

--- a/tests/test_cmd.py
+++ b/tests/test_cmd.py
@@ -35,7 +35,7 @@ def test_exec_command_log_cmd(monkeypatch, caplog):
     assert len(caplog.records) == 1
     assert caplog.records[0].levelname == "INFO"
     assert "ls -al" in caplog.records[0].message
-    assert "code=0" in caplog.records[0].message
+    assert "code 0" in caplog.records[0].message
 
 
 def test_exec_command_stderr_truncation(caplog):

--- a/tests/test_deco.py
+++ b/tests/test_deco.py
@@ -29,12 +29,19 @@ def test_handle_exception(caplog, monkeypatch):
     assert fn(1, "2") == 0
     assert len(caplog.records) == 2  # 重试了2次
 
-    # test for is_raise
+    # test for is_raise — retry_for 匹配时，重试耗尽后抛出 (line 109)
     caplog.clear()
     fn = handle_exception(test, default=0, max_retries=2, retry_for=TypeError, is_raise=True)
     with pytest.raises(TypeError):
         fn(1, "2")
     assert len(caplog.records) == 2  # 重试了2次
+
+    # test for is_raise — 异常类型不匹配 retry_for，直接抛出 (line 113)
+    caplog.clear()
+    fn = handle_exception(test, default=0, max_retries=2, retry_for=ValueError, is_raise=True)
+    with pytest.raises(TypeError):
+        fn(1, "2")
+    assert len(caplog.records) == 1  # 不匹配 retry_for，不重试，直接抛出
 
     # test for retry_delay/retry_jitter
     caplog.clear()

--- a/tests/test_deco.py
+++ b/tests/test_deco.py
@@ -95,7 +95,7 @@ def test_time_record(caplog):
     fn = time_record(test, format_key=lambda v: "key" + 1)
     fn(value)
     assert len(caplog.records) == 1
-    assert caplog.records[0].levelname == "ERROR"
+    assert caplog.records[0].levelname == "INFO"
 
     # test for other ...
 
@@ -109,3 +109,56 @@ def test_time_record(caplog):
     assert key == "-"
     assert float(cost) >= 0
     assert ret == "-"
+
+
+def test_time_record_fn_raises(caplog):
+    """lines 172-175: 被装饰函数抛异常时，应记录 ERROR 日志后 re-raise"""
+    caplog.set_level(logging.DEBUG, "pykit_tools.error")
+
+    @time_record()
+    def boom(x):
+        raise ValueError("boom!")
+
+    with pytest.raises(ValueError, match="boom!"):
+        boom("k")
+
+    assert len(caplog.records) == 1
+    record = caplog.records[0]
+    assert record.levelno == logging.ERROR
+    assert "boom!" in record.getMessage()
+    assert record.exc_info is not None
+
+
+def test_time_record_fn_raises_custom_level(caplog):
+    """lines 172-175: logger_level 参数影响异常时的日志级别"""
+    caplog.set_level(logging.DEBUG, "pykit_tools.error")
+
+    @time_record(logger_level=logging.WARNING)
+    def boom():
+        raise RuntimeError("warn-level")
+
+    with pytest.raises(RuntimeError):
+        boom()
+
+    assert caplog.records[0].levelno == logging.WARNING
+
+
+def test_time_record_format_ret_raises(caplog):
+    """lines 183-184: format_ret 抛异常时，走兜底 logger.log，原始返回值仍正常返回"""
+    caplog.set_level(logging.DEBUG, "pykit_tools.error")
+
+    def bad_format(v):
+        raise TypeError("format fail")
+
+    @time_record(format_ret=bad_format)
+    def give_value():
+        return 42
+
+    result = give_value()
+    assert result == 42
+
+    assert len(caplog.records) == 1
+    record = caplog.records[0]
+    assert record.levelno == logging.ERROR
+    assert "format fail" in record.getMessage()
+    assert record.exc_info is not None

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -37,6 +37,42 @@ def test_format_logger():
     logger.debug(dict(message="Hello world"))
 
 
+def test_get_format_logger_extra_none():
+    """extra=None (default) — _extra 只含自动注入的 hostname，不触发 update 分支"""
+    logger = adapter.get_format_logger("pykit_tools.extra_none", fields=["message"])
+    assert "hostname" in logger.extra
+    assert len(logger.extra) == 1
+
+
+def test_get_format_logger_extra_empty_dict():
+    """extra={} (falsy) — 与 None 行为一致，不触发 update 分支"""
+    logger = adapter.get_format_logger("pykit_tools.extra_empty", fields=["message"], extra={})
+    assert "hostname" in logger.extra
+    assert len(logger.extra) == 1
+
+
+def test_get_format_logger_extra_merged():
+    """extra 有值时，字段被合并进 _extra"""
+    logger = adapter.get_format_logger(
+        "pykit_tools.extra_merged",
+        fields=["message"],
+        extra={"app": "myapp", "env": "test"},
+    )
+    assert "hostname" in logger.extra
+    assert logger.extra["app"] == "myapp"
+    assert logger.extra["env"] == "test"
+
+
+def test_get_format_logger_extra_override_hostname():
+    """extra 中显式覆盖 hostname 时，自定义值生效"""
+    logger = adapter.get_format_logger(
+        "pykit_tools.extra_override",
+        fields=["message"],
+        extra={"hostname": "custom-host"},
+    )
+    assert logger.extra["hostname"] == "custom-host"
+
+
 def get_logger(name, **kwargs):
     file_name = os.path.join(os.getcwd(), f"{name}.log")
     _handler = handlers.MultiProcessTimedRotatingFileHandler(file_name, when="D", **kwargs)

--- a/tests/test_req_utils.py
+++ b/tests/test_req_utils.py
@@ -681,8 +681,8 @@ class TestRequestsLogger:
         assert "json:" in msg
         assert "response:" in msg
 
-    def test_logger_info_when_exception_str_is_empty(self, caplog):
-        """测试当异常字符串为空时使用 logger.info（覆盖 line 102）"""
+    def test_logger_error_when_exception_str_is_empty(self, caplog):
+        """测试当异常字符串为空时，仍然使用 logger_level（默认 ERROR）记录日志"""
         caplog.set_level(logging.DEBUG, "pykit_tools.requests")
 
         class EmptyStrException(Exception):
@@ -698,8 +698,8 @@ class TestRequestsLogger:
         result = mock_request("GET", "http://example.com", raise_for=None)
         assert result is None
         assert len(caplog.records) == 1
-        # 当 err = "" 时，if err 为 False，会执行 logger.info
-        assert caplog.records[0].levelname == "INFO"
+        # except 分支始终以 logger_level 记录，与异常字符串内容无关
+        assert caplog.records[0].levelname == "ERROR"
         assert "GET http://example.com" in caplog.records[0].message
 
 


### PR DESCRIPTION
- fix: 调整 `exec_command` 使用原生的 `subprocess.run` 超时参数设置
    - 解决 threading.Timer 超时带来的僵尸进程问题
- feat: 各个装饰器有logger_name参数的同时，增加 `logger_level` 参数
    - 在异常时使用的日志级别，因Sentry默认会上报ERROR日志，某些场景可以设置为`WARNING`忽略上报